### PR TITLE
Fix URL when bucket is contained in endpoint

### DIFF
--- a/s3/src/request/tokio_backend.rs
+++ b/s3/src/request/tokio_backend.rs
@@ -269,6 +269,30 @@ mod tests {
     }
 
     #[test]
+    fn test_path_style_url_ends_in_bucket() {
+        // Test case without bucket in URL
+        let region = "http://custom-region".parse().unwrap();
+        let bucket = Bucket::new("foo", region, fake_credentials())
+            .unwrap()
+            .with_path_style();
+        assert_eq!(bucket.url(), "http://custom-region/foo");
+
+        // Test case with bucket in URL
+        let region = "http://custom-region/foo".parse().unwrap();
+        let bucket = Bucket::new("foo", region, fake_credentials())
+            .unwrap()
+            .with_path_style();
+        assert_eq!(bucket.url(), "http://custom-region/foo");
+
+        // Just to make sure...
+        let region = "http://custom-region/foo".parse().unwrap();
+        let bucket = Bucket::new("bar", region, fake_credentials())
+            .unwrap()
+            .with_path_style();
+        assert_eq!(bucket.url(), "http://custom-region/foo/bar");
+    }
+
+    #[test]
     fn test_get_object_range_header() {
         let region = "http://custom-region".parse().unwrap();
         let bucket = Bucket::new("my-second-bucket", region, fake_credentials())


### PR DESCRIPTION
[![ZitaneLabs](https://badgers.space/badge/Zitane%20Labs/Open%20Source?corner_radius=s)](https://github.com/ZitaneLabs)

## TL;DR

This fixes a bug[^1] where the URL is constructed incorrectly in the case that the S3 host/endpoint already contains the bucket name in the URL and path-style URLs are enabled.

## Example

Cloudflare R2 storage specifies an URL such as this:
https://12345foo.r2.cloudflarestorage.com/my-bucket

Since the bucket is specified in the URL given by Cloudflare, but also added at the end of the endpoint, this results in requests failing with `400 Bad Request`.

## What we did

We fixed this simply by checking whether the host ends in `/{bucket_name}`, and skipping inclusion of the bucket at the end if that's the case. We also added a test case to make sure the behavior works correctly and doesn't regress.

[^1]: I'm actually not 100% sure this is really a bug, but this fix makes life easier, especially for R2 users.